### PR TITLE
Add support for generating provider configurations

### DIFF
--- a/reflex_cli/reflex_initializer.py
+++ b/reflex_cli/reflex_initializer.py
@@ -73,7 +73,10 @@ class ReflexInitializer:
             self.configs["default_email"] = "placeholder@example.com"
         else:
             self.configs["default_email"] = self.get_input("Default email:")
-        self.configs["providers"] = ["aws"]
+        region = os.environ.get("AWS_REGION")
+        if not region:
+            region = self.get_input("AWS Region:")
+        self.configs["providers"] = [{"aws": {"region": region}}]
         self.configs["measures"] = self.query_possible_measures()
 
     def render_template(self):  # pragma: no cover

--- a/reflex_cli/template_generator.py
+++ b/reflex_cli/template_generator.py
@@ -22,12 +22,23 @@ class TemplateGenerator:
 
     def create_templates(self):  # pragma: no cover
         """Generates templates for every measure in configuration."""
+        self.create_provider_templates()
         for measure in self.configuration["measures"]:
             template_name = self.determine_template_name(measure)
             LOGGER.debug("Rendering template with name: %s", template_name)
             rendered_template = self.generate_template(template_name, measure)
             if rendered_template:
                 self.write_template_file(measure, rendered_template)
+
+    def create_provider_templates(self):  # pragma: no cover
+        """Creates a simpler provider output file in terraform."""
+        for provider in self.configuration["providers"]:
+            template = self.template_env.get_template("provider.tf")
+            rendered_template = template.render(
+                provider_name=list(provider)[0],
+                region_name=provider[list(provider)[0]]["region"],
+            )
+            self.write_template_file(["providers"], rendered_template)
 
     @staticmethod
     def determine_template_name(measure):

--- a/reflex_cli/templates/provider.tf
+++ b/reflex_cli/templates/provider.tf
@@ -1,0 +1,3 @@
+provider "{{provider_name}}" {
+  region            = "{{ region_name }}"
+}


### PR DESCRIPTION
This closes #37 by adding support for generating provider configs in reflex yaml. Will need to be revisited as more complicated providers need to come on line.